### PR TITLE
Don't add a filter to comments.

### DIFF
--- a/lib/Template/AutoFilter/Parser.pm
+++ b/lib/Template/AutoFilter/Parser.pm
@@ -78,6 +78,7 @@ sub split_text {
 
         my %fields = grep { !ref } @{$token->[2]}; # filter out nested fields, they don't matter for our decision of whether there is a filter already
         next if $self->has_skip_field( \%fields );
+        next if ! %fields;
 
         push @{$token->[2]}, qw( FILTER | IDENT ), $self->{AUTO_FILTER};
     }

--- a/t/autofilter.t
+++ b/t/autofilter.t
@@ -65,6 +65,21 @@ sub tests {(
             SKIP_DIRECTIVES => [],
         },
     },
+    {
+        name => '[%# comments are parsed correctly',
+        tmpl => 'pre[%# This is a comment -%]post',
+        expect => 'prepost',
+    },
+    {
+        name => '[% # comments are parsed correctly',
+        tmpl => 'pre[% # This is a comment -%]post',
+        expect => 'prepost',
+    },
+    {
+        name => 'empty tokens are parsed correctly',
+        tmpl => 'pre[% -%]post',
+        expect => 'prepost',
+    },
 )}
 
 sub run_tests {


### PR DESCRIPTION
A tag like [% # This is a comment %] was having a filter applied to nothing, causing a parse error in TT.

Let me know if you see any problems. (Only the second of the three tests I added was failing with the previous version.)
