### PR TITLE
Add the "none" filter via define_filter.

### DIFF
--- a/lib/Template/AutoFilter.pm
+++ b/lib/Template/AutoFilter.pm
@@ -74,11 +74,16 @@ sub new {
     my $class = shift;
 
     my $params = defined($_[0]) && ref($_[0]) eq 'HASH' ? shift : {@_};
-    $params->{FILTERS}{none} ||= sub { $_[0] };
 
     $params->{PARSER} ||= Template::AutoFilter::Parser->new( $params );
 
-    return $class->SUPER::new( $params );
+    my $self = $class->SUPER::new( $params );
+
+    if ( ! $self->context->filter('none') ) {
+      $self->context->define_filter('none',sub { $_[0] });
+    }
+
+    return $self;
 }
 
 1;

--- a/t/autofilter.t
+++ b/t/autofilter.t
@@ -9,6 +9,8 @@ use Test::InDistDir;
 use Test::More 0.96 ();
 use Test::Most;
 
+use Template::Filters;
+
 run_tests();
 done_testing;
 
@@ -80,6 +82,16 @@ sub tests {(
         tmpl => 'pre[% -%]post',
         expect => 'prepost',
     },
+    {
+        name => 'none included with sent filters',
+        tmpl => '[% test | none %][% test | passed %]',
+        expect => '<a>passed<a>passed',
+        params => {
+          LOAD_FILTERS => Template::Filters->new(
+                              { FILTERS => { passed => sub { "passed$_[0]passed" } } }
+                          ),
+        },
+    }
 )}
 
 sub run_tests {


### PR DESCRIPTION
This pull request is more speculative, no offense at all if you don't think this is what Template::AutoFilter should do.

Currently if you pass a filter provider via the LOAD_FILTERS parameter to new, the "none" filter being added in Template::AutoFilter doesn't end up existing, because FILTERS is only used if no LOAD_FILTERS parameter was passed. I could certainly see the argument that if a user passed in their own LOAD_FILTERS provider they don't necessarily want it messed with. Also, if a user passes their own filter provider and it doesn't support "store", creation of a Template object will now fail. (I think maybe that's the best thing... It gives the caller a way to keep the "none" filter from being created if they really care about that for some reason.)

I could also implement this by appending another filter provider to any passed "LOAD_FILTERS" providers in the case that LOAD_FILTERS is passed, or adding to FILTERS if it is not. Or feel free to reject this entirely if you think the behavior is best as it is currently.
