### PR TITLE
Remove "use lib" bit.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module {{$dist->name}}
 
 {{$NEXT}}
+    - removed 'use lib' which breaks some people (thanks to Aran Deltac <aran@ziprecruiter.com> )
 
 0.132690  2013-09-26 10:17:29 Europe/Berlin
     - comments or empty blocks are not autofiltered anymore ( thanks to Ryan Olson <ryan@ziprecruiter.com> )

--- a/README.mkdn
+++ b/README.mkdn
@@ -63,6 +63,8 @@ new().
 
 Ryan Olson (cpan:GIMPSON) <ryan@ziprecruiter.com>
 
+Aran Deltac (cpan:BLUEFEET) <aran@ziprecruiter.com>
+
 # SUPPORT
 
 ## Bugs / Feature Requests

--- a/lib/Template/AutoFilter.pm
+++ b/lib/Template/AutoFilter.pm
@@ -67,7 +67,6 @@ Ryan Olson (cpan:GIMPSON) <ryan@ziprecruiter.com>
 
 use base 'Template';
 
-use lib '..';
 use Template::AutoFilter::Parser;
 
 sub new {


### PR DESCRIPTION
Doing "use lib" in modules is bad practice and can cause issues, such as the one that's been biting me for a while and I've finally spent the time to track down to this module.

Here's why it is bad for me, with actual names replaced with fake ones.  In my application I have this:

lib/MyApp/Foo/Bar.pm # package MyApp::Foo::Bar
lib/Foo/Bar.pm # package Foo::Bar

Now I `cd lib/MyApp`.  Then I `perl -e 'use Template::AutoFilter; use Foo::Bar'`.

The `use Foo::Bar` will actually use the MyApp::Foo::Bar module because Template::AutoFilter has popped .. onto @INC!

In my case this causes a deep recursion in Moose logic during class loading because it would try to load a class, but its package wouldn't match, and it would try again, forever.
