### PR TITLE
This commit added to apply the AutoFilter along with other filters.

### DIFF
--- a/lib/Template/AutoFilter/Parser.pm
+++ b/lib/Template/AutoFilter/Parser.pm
@@ -114,7 +114,13 @@ sub has_skip_field {
     my $skip_directives = $self->{SKIP_DIRECTIVES};
 
     for my $field ( keys %{$fields} ) {
-        return 1 if $skip_directives->{$field};
+        if (    ($skip_directives->{$field} and $field ne 'FILTER') 
+                    or 
+                (defined $fields->{IDENT}  and $fields->{IDENT} eq 'none')
+           )
+        {
+            return 1;
+        }
     }
 
     return 0;

--- a/t/autofilter.t
+++ b/t/autofilter.t
@@ -1,3 +1,4 @@
+
 #!/usr/bin/perl
 
 use strict;
@@ -32,12 +33,12 @@ sub tests {(
     },
     {
         name => 'specifically filtered tokens get filtered',
-        tmpl => '[% test | html %]',
-        expect => '&lt;a&gt;',
+        tmpl => '[% "TEXT_LOWER" | lower %]',
+        expect => 'text_lower',
     },
     {
-        name => 'other filters are applied without the autofilter',
-        tmpl => '[% test | upper %]',
+        name => 'other filters are applied without the autofilter , when none filter used',
+        tmpl => '[% test | upper | none %]',
         expect => '<A>',
     },
     {
@@ -103,6 +104,20 @@ sub tests {(
         tmpl => '[% foo=test; %][% foo %]',
         expect => '&lt;a&gt;',
     },
+    {
+        name => 'Apply AutoFilter over an existing filter in template. Multifilters parsed ok',
+        tmpl => '[% "<script>alert(\"XSS\")</script>" | lower %]',
+        expect => '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
+        params => { AUTO_FILTER => 'html' }
+    },
+    {
+        name => 'Don\'t Apply AutoFilter over an existing filter in template when none Filter used',
+        tmpl => '[% "<script>alert(\"XSS\")</script>" | lower | none %]',
+        expect => '<script>alert("xss")</script>',
+        params => { AUTO_FILTER => 'html' }
+    },
+
+
 )}
 
 sub run_tests {


### PR DESCRIPTION
Example : 
```[% name = '<script>alert("XSS")</script>TestName' %]```

         When using AutoFilter as html with existing code
         following template will not apply the AutoFilter, and it will subject to injection

```[% name | lower %]```

* This fix is to handle multiple filters along with the AutoFilter
