### PR TITLE
Skip the ASSIGN directive only when real assignment

### DIFF
--- a/lib/Template/AutoFilter/Parser.pm
+++ b/lib/Template/AutoFilter/Parser.pm
@@ -48,7 +48,7 @@ excluded. Default value is:
 
     CALL SET DEFAULT INCLUDE PROCESS WRAPPER BLOCK IF UNLESS ELSIF ELSE
     END SWITCH CASE FOREACH FOR WHILE FILTER USE MACRO TRY CATCH FINAL
-    THROW NEXT LAST RETURN STOP CLEAR META TAGS DEBUG
+    THROW NEXT LAST RETURN STOP CLEAR META TAGS DEBUG PERL RAWPERL
 
 
 =head2 make_skip_directives
@@ -117,6 +117,8 @@ sub has_skip_field {
         return 1 if $skip_directives->{$field};
     }
 
+    return 1 if $fields->{ASSIGN} and $fields->{ASSIGN} eq '=';
+
     return 0;
 }
 
@@ -125,7 +127,7 @@ sub default_skip_directives {
     my @skip_directives = qw(
         CALL SET DEFAULT INCLUDE PROCESS WRAPPER BLOCK IF UNLESS ELSIF ELSE
         END SWITCH CASE FOREACH FOR WHILE FILTER USE MACRO TRY CATCH FINAL
-        THROW NEXT LAST RETURN STOP CLEAR META TAGS DEBUG ASSIGN PERL RAWPERL
+        THROW NEXT LAST RETURN STOP CLEAR META TAGS DEBUG PERL RAWPERL
     );
     return $self->make_skip_directives( \@skip_directives );
 }

--- a/t/autofilter.t
+++ b/t/autofilter.t
@@ -103,6 +103,22 @@ sub tests {(
         tmpl => '[% foo=test; %][% foo %]',
         expect => '&lt;a&gt;',
     },
+    {
+        name => 'filtered hash as argument',
+        tmpl => '[%- USE Dumper( Indent = 0 ) -%][% Dumper.dump( hash ) %]',
+        values => { hash => { foo => '<a>' } },
+        expect => q{$VAR1 = {'foo' =&gt; '&lt;a&gt;'};},
+    },
+    {
+        name => 'filtered literal hash reference',
+        tmpl => '[%- USE Dumper( Indent = 0 ) -%][% Dumper.dump({ foo => "<a>" }) %]',
+        expect => q{$VAR1 = {'foo' =&gt; '&lt;a&gt;'};},
+    },
+    {
+        name => 'filtered literal hash',
+        tmpl => '[%- USE Dumper( Indent = 0 ) -%][% Dumper.dump( foo => "<a>" ) %]',
+        expect => q{$VAR1 = {'foo' =&gt; '&lt;a&gt;'};},
+    },
 )}
 
 sub run_tests {
@@ -118,8 +134,10 @@ sub run_test {
     $test->{params} ||= {};
 
     my $tt = Template::AutoFilter->new( $test->{params} );
+    my $values = $test->{values} // { test => '<a>' };
+
     my $out;
-    my $res = $tt->process( \$test->{tmpl}, { test => '<a>' }, \$out );
+    my $res = $tt->process( \$test->{tmpl}, $values, \$out );
 
     subtest $test->{name} => sub {
         cmp_deeply( [ $tt->error."", $res ], [ '', 1 ], 'no template errors' );


### PR DESCRIPTION
Template::Grammar labels '=>' as an ASSIGN directive.
Since the autofilter skips ASSIGN directives, literal
hashes get incorrectly skipped. This patch makes the
autofilter skip ASSIGN directives only when they use
'='.

This is an attempt at addressing [RT #118763](https://rt.cpan.org/Public/Bug/Display.html?id=118763).

I'm not sure if this is the correct solution, since it was difficult to find documentation on what the `ASSIGN` directive is supposed to be. I'll be happy to discuss alternative solutions.